### PR TITLE
[Fix] Changes state name from  to  to work around known bug

### DIFF
--- a/client/app/app.js
+++ b/client/app/app.js
@@ -66,7 +66,7 @@ angular.module('fiddio', [
     },
     controller: 'QuestionController as qv'
   })
-  .state('watch', {
+  .state('watch-answer', {
     url: '/question/:questionID/answer/:answerID',
     templateUrl: '../templates/watchAnswer.html',
     resolve: {

--- a/client/templates/answerList.html
+++ b/client/templates/answerList.html
@@ -10,7 +10,7 @@
           </div> <!-- col-xs-10 -->
           <div class="col-xs-10">
             <span>Submitted by {{ answer.owner.name }}, {{ answer.duration | date:'mm:ss' }}</span>
-            <button class="btn btn-primary btn-sm pull-right" ui-sref="watch({ questionID: {{ answer.question_id }}, answerID: {{ answer.id }}})">Watch Answer</button>
+            <button class="btn btn-primary btn-sm pull-right" ui-sref="watch-answer({ questionID: {{ answer.question_id }}, answerID: {{ answer.id }}})">Watch Answer</button>
             <p>{{answer.body}}</p>
           </div> <!-- end of col-xs-10 -->
         </div> <!-- end of row -->


### PR DESCRIPTION
[Known bug in Firefox](https://github.com/angular-ui/ui-router/wiki/Frequently-Asked-Questions#issue-firefox-is-throwing-a-bshift-is-not-a-function-error-other-browsers-are-operating-normally) regarding the state name `watch`.
